### PR TITLE
Fix silent error for Columns with null values

### DIFF
--- a/src/Serilog.Sinks.Postgresql.Alternative/Sinks/PostgreSQL/SinkHelper.cs
+++ b/src/Serilog.Sinks.Postgresql.Alternative/Sinks/PostgreSQL/SinkHelper.cs
@@ -111,7 +111,7 @@ public class SinkHelper
                 command.Parameters.AddWithValue(
                     ClearColumnNameForParameterName(columnKey),
                     this.SinkOptions.ColumnOptions[columnKey].DbType,
-                    this.SinkOptions.ColumnOptions[columnKey].GetValue(logEvent, this.SinkOptions.FormatProvider));
+                    this.SinkOptions.ColumnOptions[columnKey].GetValue(logEvent, this.SinkOptions.FormatProvider)) ?? DBNull.Value;
             }
 
             await command.ExecuteNonQueryAsync();


### PR DESCRIPTION
When pushing log entries through the multiple sinks I had logs showing on console + log file but not on Postgres DB. After investigating the issue I noticed that null values were not getting assigned DBNull.Value therefore it would throw a silent exception and the log entries were ignored