### PR TITLE
Mask timestamp column name

### DIFF
--- a/src/Serilog.Sinks.Postgresql.Alternative/Sinks/PostgreSQL/SinkHelper.cs
+++ b/src/Serilog.Sinks.Postgresql.Alternative/Sinks/PostgreSQL/SinkHelper.cs
@@ -259,7 +259,9 @@ public sealed class SinkHelper
         builder.Append('"');
 
         builder.Append(" WHERE ");
+        builder.Append('"');
         builder.Append(timestampColumnName);
+        builder.Append('"');
         builder.Append(" < @cutoffDate;");
         return builder.ToString();
     }


### PR DESCRIPTION
This PR masks the timestamp column name in order to be case-sensitive.